### PR TITLE
Improve professional dashboard location permission handling

### DIFF
--- a/frontend/src/Pages/Dashboard/ProfessionalDashboard/ProfessionalDasboardWrapper.jsx
+++ b/frontend/src/Pages/Dashboard/ProfessionalDashboard/ProfessionalDasboardWrapper.jsx
@@ -1,33 +1,122 @@
-import useSocketStore from '../../../store/useSocketStore'
-import { useEffect } from 'react'
-import { watchLocation } from '../../../utils/geoLocation.utils'
+import { useEffect, useMemo, useState } from 'react'
 import { Outlet } from 'react-router-dom'
+import useSocketStore from '../../../store/useSocketStore'
+import { getBrowserLocation, watchLocation } from '../../../utils/geoLocation.utils'
+
+const OVERLAY_MESSAGES = {
+  initial: 'Getting your location… Please wait',
+  prompt: 'Location access needed – please allow',
+  denied: 'Location permission denied. Please enable it in browser settings to continue.',
+  failed: 'Unable to detect location. Please turn on GPS/location services.',
+}
 
 // This is a wrapper component for the professional dashboard.
 // step 1 set up the socket connection
 // step 2 watch the user's location
 const ProfessionalDasboardWrapper = () => {
+  const isConnected = useSocketStore(state => state.isConnected)
+  const [isLocating, setIsLocating] = useState(true)
+  const [hasCoordinates, setHasCoordinates] = useState(false)
+  const [messageKey, setMessageKey] = useState('initial')
+
   useEffect(() => {
     const initializeSocket = useSocketStore.getState().initializeSocket
     const cleanup = useSocketStore.getState().cleanup
-    const isConnected = useSocketStore.getState().isConnected
 
     let watchId = null
-    if (!isConnected) {
-      initializeSocket()
-      watchId = watchLocation()
+    let isMounted = true
+
+    const startProfessionalSession = async () => {
+      if (!('geolocation' in navigator)) {
+        setMessageKey('failed')
+        setIsLocating(false)
+        return
+      }
+
+      setMessageKey('initial')
+
+      try {
+        const permissionStatus = await navigator.permissions?.query({ name: 'geolocation' })
+
+        if (permissionStatus?.state === 'denied') {
+          setMessageKey('denied')
+          setIsLocating(false)
+          return
+        }
+
+        if (permissionStatus?.state === 'prompt') {
+          setMessageKey('prompt')
+        }
+      } catch {
+        // Safari can throw for navigator.permissions. We'll continue with geolocation request.
+      }
+
+      try {
+        const location = await getBrowserLocation()
+        if (!isMounted) {
+          return
+        }
+
+        setHasCoordinates(true)
+        await initializeSocket(location)
+        watchId = watchLocation()
+      } catch (error) {
+        if (!isMounted) {
+          return
+        }
+
+        const deniedPermission =
+          error?.code === 1 ||
+          `${error?.message || ''}`.toLowerCase().includes('denied') ||
+          `${error?.message || ''}`.toLowerCase().includes('permission')
+
+        setMessageKey(deniedPermission ? 'denied' : 'failed')
+        setIsLocating(false)
+      }
     }
 
+    startProfessionalSession()
+
     return () => {
+      isMounted = false
       cleanup()
       if (watchId !== null) navigator.geolocation.clearWatch(watchId)
     }
   }, [])
-  return (
-    <div>
-      <Outlet />
-    </div>
+
+  useEffect(() => {
+    if (isConnected && hasCoordinates) {
+      setIsLocating(false)
+    }
+  }, [hasCoordinates, isConnected])
+
+  const locationReady = isConnected && hasCoordinates
+  const isBlocked = !locationReady && !isLocating
+  const loaderMessage = useMemo(
+    () => OVERLAY_MESSAGES[messageKey] || OVERLAY_MESSAGES.initial,
+    [messageKey]
   )
+
+  if (!locationReady) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-[#060b22] px-6 text-center text-white">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-white/25 border-t-white" />
+        <p className="max-w-md text-base font-medium">{loaderMessage}</p>
+        {isBlocked && messageKey === 'denied' ? (
+          <a
+            href="https://support.google.com/chrome/answer/142065"
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm text-blue-300 underline"
+          >
+            How to enable location access
+          </a>
+        ) : null}
+      </div>
+    )
+  }
+
+  return <Outlet />
 }
 
 export default ProfessionalDasboardWrapper

--- a/frontend/src/store/useSocketStore.js
+++ b/frontend/src/store/useSocketStore.js
@@ -9,12 +9,13 @@ const useSocketStore = create((set, get) => ({
   hasInitialized: false,
 
   // Professional socket initialization
-  initializeSocket: async () => {
+  initializeSocket: async initialLocation => {
     if (get().hasInitialized) {
       return
     }
 
-    const { longitude, latitude } = await getBrowserLocation()
+    const location = initialLocation ?? (await getBrowserLocation())
+    const { longitude, latitude } = location
 
     socket.on('connect', () => {
       console.log('✓ Socket connected (Professional)')


### PR DESCRIPTION
### Motivation
- The professional dashboard previously rendered an empty/blank screen when geolocation permission was denied, not yet granted, or GPS was off, leaving pros without feedback or a way forward.
- The dashboard flow depends on location and socket connectivity, so the UI must block rendering until both are available and provide clear guidance when location is unavailable.

### Description
- Added a full-screen blocking overlay in `ProfessionalDasboardWrapper` that shows a centered spinner and conditional messages for `initial`, `prompt`, `denied`, and `failed` location states and prevents rendering the dashboard until ready.
- Introduced local state flags (`isLocating`, `hasCoordinates`, `messageKey`) and permission-aware startup logic that queries `navigator.permissions` when available and calls `getBrowserLocation` before initializing the socket and starting `watchLocation`.
- Updated `initializeSocket` in `useSocketStore` to accept optional pre-fetched coordinates so the wrapper can control error handling and only connect once valid coords are available.
- Added a small help link for the denied-permission state and kept the change minimal and isolated to the professional dashboard wrapper and socket init logic.

### Testing
- Ran ESLint on the modified files with `cd frontend && npx eslint src/Pages/Dashboard/ProfessionalDashboard/ProfessionalDasboardWrapper.jsx src/store/useSocketStore.js` and it passed after fixes.
- Launched the dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` to validate UI behavior and manually inspected the overlay, which started successfully.
- Captured an automated browser screenshot of the overlay using Playwright to verify the blocking loader state (screenshot artifact created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699842e1c158832bbec09185aaaab434)