### PR TITLE
Start geolocation on explicit Post Job click; add inline validation, image cap, and full-screen submission feedback

### DIFF
--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/PostJob.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/PostJob.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import Step1 from './Step1'
 import Step2 from './Step2'
 import Step3 from './Step3'
@@ -7,9 +7,17 @@ import Step5 from './Step5'
 import Step6 from './Step6'
 import Step7 from './Step7'
 import useJobStore from '../../../../../store/useJobStore'
+import { getBrowserLocation } from '../../../../../utils/geoLocation.utils'
+
+const LOCATION_OVERLAY_MESSAGES = {
+  initial: 'Getting your location… Please wait',
+  prompt: 'Location access needed – please allow',
+  denied: 'Location permission denied. Please enable it in your browser settings to continue.',
+  failed: 'Unable to detect location. Please turn on GPS/location services.',
+}
 
 export default function PostJobPage() {
-  const loading = useJobStore(state => state.loading) // Hooking into global store state
+  const loading = useJobStore(state => state.loading)
   const [step, setStep] = useState(1)
   const [formData, setFormData] = useState({
     title: '',
@@ -22,33 +30,122 @@ export default function PostJobPage() {
     scheduledAt: '',
   })
 
+  const [locationReady, setLocationReady] = useState(false)
+  const [hasStartedLocationCheck, setHasStartedLocationCheck] = useState(false)
+  const [isLocating, setIsLocating] = useState(false)
+  const [messageKey, setMessageKey] = useState('initial')
+
+  const initializeLocation = async () => {
+    setHasStartedLocationCheck(true)
+    setLocationReady(false)
+    setIsLocating(true)
+
+    if (!('geolocation' in navigator)) {
+      setMessageKey('failed')
+      setIsLocating(false)
+      return
+    }
+
+    setMessageKey('initial')
+
+    try {
+      const permissionStatus = await navigator.permissions?.query({ name: 'geolocation' })
+
+      if (permissionStatus?.state === 'denied') {
+        setMessageKey('denied')
+        setIsLocating(false)
+        return
+      }
+
+      if (permissionStatus?.state === 'prompt') {
+        setMessageKey('prompt')
+      }
+    } catch {
+      // Safari may throw for navigator.permissions
+    }
+
+    try {
+      await getBrowserLocation()
+      setLocationReady(true)
+    } catch (error) {
+      const deniedPermission =
+        `${error?.message || ''}`.toLowerCase().includes('denied') ||
+        `${error?.message || ''}`.toLowerCase().includes('permission')
+
+      setMessageKey(deniedPermission ? 'denied' : 'failed')
+    } finally {
+      setIsLocating(false)
+    }
+  }
+
+  const locationMessage = useMemo(
+    () => LOCATION_OVERLAY_MESSAGES[messageKey] || LOCATION_OVERLAY_MESSAGES.initial,
+    [messageKey]
+  )
+
+  const blockedState = hasStartedLocationCheck && !locationReady && !isLocating
+
   return (
     <div className="relative w-[90%]">
-      {/* 1. Loading Overlay Modal */}
+      {hasStartedLocationCheck && !locationReady && (
+        <div className="fixed inset-0 z-[110] flex flex-col items-center justify-center gap-4 bg-[rgb(15,15,16)] px-6 text-center text-white">
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-[#32cd32] border-t-transparent" />
+          <p className="max-w-md text-base font-medium">{locationMessage}</p>
+          {blockedState ? (
+            <p className="max-w-md text-sm text-zinc-300">
+              Refresh after enabling location access to continue posting your job.
+            </p>
+          ) : null}
+        </div>
+      )}
+
       {loading && (
         <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center bg-black/60 backdrop-blur-md transition-all">
           <div className="flex w-[85%] max-w-sm flex-col items-center rounded-3xl bg-[#0f0f10] p-8 shadow-2xl">
-            {/* Simple CSS Spinner */}
             <div className="h-14 w-14 animate-spin rounded-full border-4 border-gray-100 border-t-[#32cd32]"></div>
 
-            <h2 className="mt-6 text-center text-xl font-bold text-[#32cd32]">
-              Publishing Your Job
-            </h2>
+            <h2 className="mt-6 text-center text-xl font-bold text-[#32cd32]">Publishing Your Job</h2>
             <p className="mt-2 text-center text-sm text-gray-500">
-              We're uploading your images and pinpointing your location...
+              We&apos;re uploading your images and publishing your job...
             </p>
           </div>
         </div>
       )}
 
-      {/* 2. Step Rendering */}
-      {step === 1 && <Step1 setStep={setStep} setFormData={setFormData} formData={formData} />}
-      {step === 2 && <Step2 setStep={setStep} setFormData={setFormData} formData={formData} />}
-      {step === 3 && <Step3 setStep={setStep} setFormData={setFormData} formData={formData} />}
-      {step === 4 && <Step4 setStep={setStep} setFormData={setFormData} formData={formData} />}
-      {step === 5 && <Step5 setStep={setStep} setFormData={setFormData} formData={formData} />}
-      {step === 6 && <Step6 setStep={setStep} setFormData={setFormData} formData={formData} />}
-      {step === 7 && <Step7 setFormData={setFormData} formData={formData} />}
+      {!hasStartedLocationCheck && !locationReady && (
+        <div className="mx-auto flex min-h-[50vh] w-full max-w-xl flex-col items-center justify-center rounded-2xl border border-zinc-800 bg-[#131314] px-6 py-10 text-center">
+          <h2 className="text-2xl font-bold text-white">Post a job</h2>
+          <p className="mt-3 max-w-md text-sm text-zinc-400">
+            We need your location before you continue so professionals near you can find this job.
+          </p>
+          <button
+            onClick={initializeLocation}
+            className="mt-6 w-full max-w-xs rounded-xl bg-[#32cd32] px-6 py-3 text-base font-semibold text-black"
+          >
+            Post Job
+          </button>
+        </div>
+      )}
+
+      {locationReady && step === 1 && (
+        <Step1 setStep={setStep} setFormData={setFormData} formData={formData} />
+      )}
+      {locationReady && step === 2 && (
+        <Step2 setStep={setStep} setFormData={setFormData} formData={formData} />
+      )}
+      {locationReady && step === 3 && (
+        <Step3 setStep={setStep} setFormData={setFormData} formData={formData} />
+      )}
+      {locationReady && step === 4 && (
+        <Step4 setStep={setStep} setFormData={setFormData} formData={formData} />
+      )}
+      {locationReady && step === 5 && (
+        <Step5 setStep={setStep} setFormData={setFormData} formData={formData} />
+      )}
+      {locationReady && step === 6 && (
+        <Step6 setStep={setStep} setFormData={setFormData} formData={formData} />
+      )}
+      {locationReady && step === 7 && <Step7 setFormData={setFormData} formData={formData} />}
     </div>
   )
 }

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step1.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step1.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { CheckCircle2 } from 'lucide-react'
 
 const Step1 = ({ setStep, setFormData, formData }) => {
   const categories = [
@@ -19,46 +19,46 @@ const Step1 = ({ setStep, setFormData, formData }) => {
     'Tiling',
   ]
 
-  const [selectedCategory, setSelectedCategory] = useState('')
+  const selectedCategory = formData.category || ''
+  const isValid = Boolean(selectedCategory)
+
   return (
-    <>
-      <div>
-        <h2 className="mb-4 text-2xl font-semibold">What kind of job is it?</h2>
+    <div>
+      <h2 className="mb-4 text-2xl font-semibold">What kind of job is it?</h2>
 
-        <div className="mb-8 flex flex-wrap gap-3">
-          {categories.map(cat => (
-            <button
-              key={cat}
-              onClick={() => setSelectedCategory(cat)}
-              className={`rounded-full border px-5 py-2 text-sm transition ${
-                selectedCategory === cat
-                  ? 'border-[#32cd32] bg-[#32cd32]/10 text-[#32cd32]'
-                  : 'border-gray-700 text-gray-300 hover:border-[#32cd32]'
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
-        </div>
-
-        <div className="flex justify-end">
+      <div className="mb-2 flex flex-wrap gap-3">
+        {categories.map(cat => (
           <button
-            disabled={!selectedCategory}
-            onClick={() => {
-              setStep(2)
-              setFormData({ ...formData, category: selectedCategory })
-            }}
-            className={`rounded-xl px-6 py-3 font-medium ${
-              selectedCategory
-                ? 'bg-[#32cd32] text-black'
-                : 'cursor-not-allowed bg-gray-700 text-gray-400'
+            key={cat}
+            onClick={() => setFormData({ ...formData, category: cat })}
+            className={`rounded-full border px-5 py-2 text-sm transition ${
+              selectedCategory === cat
+                ? 'border-[#32cd32] bg-[#32cd32]/10 text-[#32cd32]'
+                : 'border-gray-700 text-gray-300 hover:border-[#32cd32]'
             }`}
           >
-            Next
+            {cat}
           </button>
-        </div>
+        ))}
       </div>
-    </>
+
+      <p className={`mb-8 flex items-center gap-2 text-sm ${isValid ? 'text-[#32cd32]' : 'text-red-400'}`}>
+        {isValid ? <CheckCircle2 size={16} /> : null}
+        {isValid ? 'Category selected' : 'Category is required'}
+      </p>
+
+      <div className="flex justify-end">
+        <button
+          disabled={!isValid}
+          onClick={() => setStep(2)}
+          className={`rounded-xl px-6 py-3 font-medium ${
+            isValid ? 'bg-[#32cd32] text-black' : 'pointer-events-none bg-gray-700 text-gray-400'
+          }`}
+        >
+          Next
+        </button>
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step2.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step2.jsx
@@ -1,18 +1,19 @@
-import React, { useState } from 'react'
+import { CheckCircle2 } from 'lucide-react'
 
 const Step2 = ({ setStep, setFormData, formData }) => {
-  const [title, setTitle] = useState('')
-  const [charLeft, setCharLeft] = useState(120)
+  const title = formData.title || ''
+  const maxLength = 60
+  const trimmedTitle = title.trim()
+  const charLeft = maxLength - title.length
+  const isValid = trimmedTitle.length > 0
+
   const handleChange = e => {
     const value = e.target.value
-    const left = 60 - value.length
-
-    // Use the local 'left' variable so the logic is instant
-    if (left >= 0) {
-      setCharLeft(left)
-      setTitle(value)
+    if (value.length <= maxLength) {
+      setFormData({ ...formData, title: value })
     }
   }
+
   return (
     <div>
       <span className="mb-4 text-2xl font-semibold">Job Title — Keep it short and specific.</span>
@@ -25,14 +26,21 @@ const Step2 = ({ setStep, setFormData, formData }) => {
         />
       </div>
 
-      <div className="mt-6 flex justify-end space-y-12">
-        <span className="">Characters left : {charLeft}</span>
+      <div className="mt-3 flex items-center justify-between text-sm">
+        <span className={isValid ? 'flex items-center gap-2 text-[#32cd32]' : 'text-red-400'}>
+          {isValid ? <CheckCircle2 size={16} /> : null}
+          {isValid ? 'Title looks good' : 'Title is required'}
+        </span>
+        <span className="text-gray-400">Characters left: {charLeft}</span>
+      </div>
+
+      <div className="mt-6 flex justify-end">
         <button
-          onClick={() => {
-            setStep(3)
-            setFormData({ ...formData, title: title })
-          }}
-          className="rounded-xl bg-[#32cd32] px-6 py-3 font-medium text-black"
+          disabled={!isValid}
+          onClick={() => setStep(3)}
+          className={`rounded-xl px-6 py-3 font-medium ${
+            isValid ? 'bg-[#32cd32] text-black' : 'pointer-events-none bg-gray-700 text-gray-400'
+          }`}
         >
           Next
         </button>

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step4.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step4.jsx
@@ -1,17 +1,27 @@
-import React from 'react'
+import { useState } from 'react'
 import { PhotoIcon, XMarkIcon } from '@heroicons/react/24/outline'
 
+const MAX_IMAGES = 5
+
 const Step4 = ({ setStep, formData, setFormData }) => {
+  const [imageError, setImageError] = useState('')
+
   const handleFileChange = e => {
-    // Basic check to ensure files were actually selected
     if (!e.target.files) return
 
     const files = Array.from(e.target.files)
+    const currentCount = formData.images?.length || 0
+    const total = currentCount + files.length
 
-    // Create preview URLs
+    if (total > MAX_IMAGES) {
+      setImageError('Maximum 5 images allowed')
+      e.target.value = ''
+      return
+    }
+
+    setImageError('')
     const newPreviews = files.map(file => URL.createObjectURL(file))
 
-    // Update state
     setFormData({
       ...formData,
       images: [...(formData.images || []), ...files],
@@ -23,23 +33,24 @@ const Step4 = ({ setStep, formData, setFormData }) => {
     const updatedImages = formData.images.filter((_, i) => i !== index)
     const updatedPreviews = formData.previews.filter((_, i) => i !== index)
     setFormData({ ...formData, images: updatedImages, previews: updatedPreviews })
+    setImageError('')
   }
+
+  const imageCount = formData.images?.length || 0
 
   return (
     <div>
       <h2 className="mb-2 text-2xl font-semibold">Show us what’s going on</h2>
-      <p className="mb-6 text-gray-400">Pictures help workers understand the job faster</p>
+      <p className="mb-3 text-gray-400">Pictures help workers understand the job faster</p>
+      <p className="mb-6 text-sm text-zinc-400">Images are optional. You can upload up to 5 photos.</p>
 
-      {/* The 'htmlFor' links this label to the input ID. 
-          Clicking anywhere inside this label opens the file picker.
-      */}
-      {(!formData.images || formData.images.length === 0) && (
+      {imageCount < MAX_IMAGES && (
         <label
           htmlFor="file-upload"
           className="block cursor-pointer rounded-2xl border-2 border-dashed border-gray-700 p-10 text-center transition hover:border-[#32cd32] hover:bg-gray-800"
         >
           <PhotoIcon className="mx-auto mb-4 h-12 w-12 text-gray-400" />
-          <p className="font-medium text-gray-400">Click to upload photos</p>
+          <p className="font-medium text-gray-400">Click to upload photos ({imageCount}/5)</p>
 
           <input
             id="file-upload"
@@ -52,7 +63,8 @@ const Step4 = ({ setStep, formData, setFormData }) => {
         </label>
       )}
 
-      {/* Preview Grid */}
+      {imageError ? <p className="mt-3 text-sm text-red-400">{imageError}</p> : null}
+
       <div className="mt-6 grid grid-cols-3 gap-4">
         {formData.previews?.map((url, index) => (
           <div key={index} className="relative h-24 w-full">

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step5.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step5.jsx
@@ -1,12 +1,18 @@
-import React, { useState } from 'react'
+import { CheckCircle2 } from 'lucide-react'
 
 const Step5 = ({ setStep, setFormData, formData }) => {
-  const [budget, setBudget] = useState('')
+  const budgetInput = formData.budget ? new Intl.NumberFormat('en-NG').format(formData.budget) : ''
+  const budgetValue = Number(formData.budget || 0)
+  const isValid = Number.isFinite(budgetValue) && budgetValue > 0
 
   const handleChange = e => {
-    let value = e.target.value.replace(/\D/g, '')
-    value = new Intl.NumberFormat('en-NG').format(value)
-    setBudget(value)
+    const digitsOnly = e.target.value.replace(/\D/g, '')
+    if (!digitsOnly) {
+      setFormData({ ...formData, budget: '' })
+      return
+    }
+
+    setFormData({ ...formData, budget: parseInt(digitsOnly, 10) })
   }
 
   return (
@@ -18,21 +24,27 @@ const Step5 = ({ setStep, setFormData, formData }) => {
         <span className="absolute left-4 top-1/2 -translate-y-1/2 text-2xl text-gray-400">₦</span>
         <input
           type="text"
-          value={budget}
+          value={budgetInput}
           onChange={handleChange}
           placeholder="Enter your budget"
           className="w-full rounded-2xl border border-gray-700 bg-[#0f0f10] py-3 pl-10 pr-4 text-center text-3xl font-extrabold tracking-widest text-[#32cd32] placeholder:align-middle placeholder:text-[1.2rem] placeholder:text-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#32cd32]"
         />
       </div>
 
+      <p className={`mt-3 text-sm ${isValid ? 'flex items-center gap-2 text-[#32cd32]' : 'text-red-400'}`}>
+        {isValid ? <CheckCircle2 size={16} /> : null}
+        {isValid ? 'Budget is valid' : 'Budget must be greater than 0'}
+      </p>
+
       <div className="mt-6 flex justify-end">
         <button
-          onClick={() => {
-            setStep(6)
-            const cleanBudget = budget.replace(/,/g, '')
-            setFormData({ ...formData, budget: parseInt(cleanBudget) })
-          }}
-          className="rounded-2xl bg-[#32cd32] px-6 py-3 font-medium text-black shadow-md transition hover:bg-[#28a428] hover:shadow-lg"
+          disabled={!isValid}
+          onClick={() => setStep(6)}
+          className={`rounded-2xl px-6 py-3 font-medium shadow-md transition ${
+            isValid
+              ? 'bg-[#32cd32] text-black hover:bg-[#28a428] hover:shadow-lg'
+              : 'pointer-events-none bg-gray-700 text-gray-400'
+          }`}
         >
           Next
         </button>

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step6.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step6.jsx
@@ -1,18 +1,15 @@
-import React, { useState } from 'react'
+import { CheckCircle2 } from 'lucide-react'
 
 const Step6 = ({ setStep, setFormData, formData }) => {
-  // Initializing with existing data if the user goes "Back" and "Forward"
-  const [address, setAddress] = useState(formData.address || '')
-  const [charLeft, setCharLeft] = useState(100 - (formData.address?.length || 0))
+  const address = formData.address || ''
+  const limit = 100
+  const charLeft = limit - address.length
+  const isValid = address.trim().length > 0
 
   const handleChange = e => {
     const value = e.target.value
-    const limit = 100
-    const left = limit - value.length
-
-    if (left >= 0) {
-      setCharLeft(left)
-      setAddress(value)
+    if (value.length <= limit) {
+      setFormData({ ...formData, address: value })
     }
   }
 
@@ -31,28 +28,28 @@ const Step6 = ({ setStep, setFormData, formData }) => {
         />
       </div>
 
-      <div className="mt-6 flex flex-col items-end space-y-4">
-        <span className="text-sm text-gray-500">Characters left: {charLeft}</span>
+      <div className="mt-3 flex items-center justify-between text-sm">
+        <span className={isValid ? 'flex items-center gap-2 text-[#32cd32]' : 'text-red-400'}>
+          {isValid ? <CheckCircle2 size={16} /> : null}
+          {isValid ? 'Address looks good' : 'Address is required'}
+        </span>
+        <span className="text-gray-500">Characters left: {charLeft}</span>
+      </div>
 
-        <div className="flex w-full justify-between">
-          {/* Back button is usually helpful in multi-step */}
-          <button onClick={() => setStep(5)} className="text-gray-400 transition hover:text-white">
-            Back
-          </button>
+      <div className="mt-6 flex w-full justify-between">
+        <button onClick={() => setStep(5)} className="text-gray-400 transition hover:text-white">
+          Back
+        </button>
 
-          <button
-            onClick={() => {
-              if (address.trim().length < 5) {
-                return alert('Please enter a more specific address.')
-              }
-              setFormData({ ...formData, address: address })
-              setStep(7)
-            }}
-            className="rounded-xl bg-[#32cd32] px-10 py-3 font-medium text-black transition hover:bg-[#2dbd2d]"
-          >
-            Next
-          </button>
-        </div>
+        <button
+          disabled={!isValid}
+          onClick={() => setStep(7)}
+          className={`rounded-xl px-10 py-3 font-medium transition ${
+            isValid ? 'bg-[#32cd32] text-black hover:bg-[#2dbd2d]' : 'pointer-events-none bg-gray-700 text-gray-400'
+          }`}
+        >
+          Next
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step7.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step7.jsx
@@ -1,55 +1,70 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Calendar, Clock, CheckCircle2 } from 'lucide-react'
 import useJobStore from '../../../../../store/useJobStore'
 import useClientStore from '../../../../../store/useClientStore'
-import { useNavigate } from 'react-router-dom'
-import { toast } from 'react-hot-toast'
 
-const Step7 = ({ setFormData, formData }) => {
+const Step7 = ({ formData }) => {
   const setMainTab = useClientStore(state => state.setMainTab)
-  const navigate = useNavigate()
+  const postJob = useJobStore(state => state.postJob)
+  const loading = useJobStore(state => state.loading)
+
   const [when, setWhen] = useState('today')
   const [date, setDate] = useState('')
   const [time, setTime] = useState('')
-  const postJob = useJobStore(state => state.postJob)
-  const loading = useJobStore(state => state.loading)
-  const error = useJobStore(state => state.error)
+  const [feedback, setFeedback] = useState({ isOpen: false, type: 'success', message: '' })
+
+  const titleValid = formData.title?.trim().length > 0
+  const categoryValid = Boolean(formData.category)
+  const budgetValid = Number(formData.budget) > 0
+  const addressValid = formData.address?.trim().length > 0
+
+  const scheduleValidation = useMemo(() => {
+    if (when === 'today') {
+      return { valid: true, isoDate: new Date().toISOString(), text: 'ASAP selected' }
+    }
+
+    if (!date || !time) {
+      return { valid: false, isoDate: null, text: 'Date and time are required' }
+    }
+
+    const selectedDate = new Date(`${date}T${time}`)
+    if (Number.isNaN(selectedDate.getTime()) || selectedDate <= new Date()) {
+      return { valid: false, isoDate: null, text: 'Please choose a future date/time' }
+    }
+
+    return { valid: true, isoDate: selectedDate.toISOString(), text: 'Schedule is valid' }
+  }, [date, time, when])
+
+  const formReadyToPost =
+    categoryValid && titleValid && budgetValid && addressValid && scheduleValidation.valid
 
   const handleSubmit = async () => {
-    let baseDate
-
-    if (when === 'today') {
-      baseDate = new Date()
-    } else if (when === 'date') {
-      baseDate = new Date(date)
-      const [hours, minutes] = time.split(':')
-      baseDate.setHours(parseInt(hours), parseInt(minutes), 0, 0)
-    } else {
-      baseDate = 'yh dates not working'
+    if (!formReadyToPost || loading) {
+      return
     }
-
-    const updatedFormData = { ...formData, scheduledAt: baseDate.toISOString() }
-    console.log(updatedFormData)
 
     try {
-      const result = await postJob(updatedFormData)
+      await postJob({ ...formData, scheduledAt: scheduleValidation.isoDate })
+      setFeedback({ isOpen: true, type: 'success', message: 'Job posted successfully!' })
 
-      // If postJob didn't throw an error, it's a success
-      toast.success('Job posted successfully!')
-
-      // Simple check: if we got a result, move them out
-      if (result) {
+      setTimeout(() => {
+        setFeedback({ isOpen: false, type: 'success', message: '' })
         setMainTab('home')
-      }
+      }, 3500)
     } catch (error) {
-      toast.error(error.response?.data?.message || 'Something went wrong')
+      const reason = error?.response?.data?.message
+      setFeedback({
+        isOpen: true,
+        type: 'error',
+        message: reason
+          ? `There was an error posting your job. Please try again. ${reason}`
+          : 'There was an error posting your job. Please try again.',
+      })
     }
   }
-  // Tailwind classes for the Zinc theme
+
   const cardBase =
     'relative flex flex-1 flex-col items-center justify-center p-6 rounded-2xl border-2 transition-all duration-200 cursor-pointer'
-
-  // Zinc 900/800 for depth, Zinc 400 for text
   const activeCard = `border-[#32cd32] bg-zinc-900 ring-1 ring-[#32cd32]`
   const inactiveCard = 'border-zinc-800 bg-zinc-900/50 hover:border-zinc-700 text-zinc-500'
 
@@ -60,87 +75,141 @@ const Step7 = ({ setFormData, formData }) => {
   `
 
   return (
-    <div className="mx-auto w-full font-sans text-zinc-100 ">
-      <header className="mb-8 text-center sm:text-left">
-        <h2 className="text-2xl font-bold tracking-tight text-white">When do you want it done?</h2>
-        <p className="mt-1 text-zinc-400">Select your preferred schedule</p>
-      </header>
-
-      {/* Toggle Cards */}
-      <div className="mb-8 flex gap-4">
-        <div
-          onClick={() => setWhen('today')}
-          className={`${cardBase} ${when === 'today' ? activeCard : inactiveCard}`}
-          style={when === 'today' ? { borderColor: '#32cd32' } : {}}
-        >
-          {when === 'today' && (
-            <CheckCircle2 size={18} className="absolute right-3 top-3 text-[#32cd32]" />
-          )}
-          <Calendar size={28} className={when === 'today' ? 'text-[#32cd32]' : 'text-zinc-600'} />
-          <span
-            className={`mt-3 font-semibold ${when === 'today' ? 'text-white' : 'text-zinc-500'}`}
-          >
-            Today
-          </span>
-        </div>
-
-        <div
-          onClick={() => setWhen('date')}
-          className={`${cardBase} ${when === 'date' ? activeCard : inactiveCard}`}
-          style={when === 'date' ? { borderColor: '#32cd32' } : {}}
-        >
-          {when === 'date' && (
-            <CheckCircle2 size={18} className="absolute right-3 top-3 text-[#32cd32]" />
-          )}
-          <Clock size={28} className={when === 'date' ? 'text-[#32cd32]' : 'text-zinc-600'} />
-          <span
-            className={`mt-3 font-semibold ${when === 'date' ? 'text-white' : 'text-zinc-500'}`}
-          >
-            Schedule
-          </span>
-        </div>
-      </div>
-
-      {/* Custom Form Section */}
-      {when === 'date' && (
-        <div className="space-y-4 duration-300 animate-in fade-in slide-in-from-top-3">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div className="flex flex-col gap-2">
-              <label className="ml-1 text-xs font-bold uppercase tracking-widest text-zinc-500">
-                Date
-              </label>
-              <input
-                type="date"
-                className={inputClass}
-                value={date}
-                onChange={e => setDate(e.target.value)}
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <label className="ml-1 text-xs font-bold uppercase tracking-widest text-zinc-500">
-                Time
-              </label>
-              <input
-                type="time"
-                className={inputClass}
-                value={time}
-                onChange={e => setTime(e.target.value)}
-              />
-            </div>
+    <>
+      {feedback.isOpen && (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center bg-[rgb(15,15,16)] px-6 text-center text-white">
+          <div className="w-full max-w-md rounded-2xl border border-zinc-700 bg-zinc-900 p-8">
+            <h3
+              className={`text-2xl font-bold ${
+                feedback.type === 'success' ? 'text-[#32cd32]' : 'text-red-400'
+              }`}
+            >
+              {feedback.type === 'success'
+                ? 'Job posted successfully!'
+                : 'There was an error posting your job. Please try again.'}
+            </h3>
+            <p className="mt-3 text-sm text-zinc-300">{feedback.message}</p>
+            {feedback.type === 'success' ? (
+              <button
+                onClick={() => setMainTab('home')}
+                className="mt-6 w-full rounded-xl bg-[#32cd32] py-3 font-semibold text-black"
+              >
+                View your job
+              </button>
+            ) : (
+              <button
+                onClick={() => setFeedback({ isOpen: false, type: 'error', message: '' })}
+                className="mt-6 w-full rounded-xl border border-zinc-600 py-3 font-semibold text-white"
+              >
+                Close
+              </button>
+            )}
           </div>
         </div>
       )}
 
-      {/* Action Button */}
-      <div className="mt-10">
-        <button
-          onClick={handleSubmit}
-          className="w-full rounded-2xl bg-[#32cd32] py-4 font-black uppercase tracking-tight text-black shadow-lg shadow-[#32cd32]/10 transition-all hover:brightness-110 active:scale-[0.97]"
-        >
-          Post Job
-        </button>
+      <div className="mx-auto w-full font-sans text-zinc-100 ">
+        <header className="mb-8 text-center sm:text-left">
+          <h2 className="text-2xl font-bold tracking-tight text-white">When do you want it done?</h2>
+          <p className="mt-1 text-zinc-400">Select your preferred schedule</p>
+        </header>
+
+        <div className="mb-8 flex gap-4">
+          <div
+            onClick={() => setWhen('today')}
+            className={`${cardBase} ${when === 'today' ? activeCard : inactiveCard}`}
+            style={when === 'today' ? { borderColor: '#32cd32' } : {}}
+          >
+            {when === 'today' && (
+              <CheckCircle2 size={18} className="absolute right-3 top-3 text-[#32cd32]" />
+            )}
+            <Calendar size={28} className={when === 'today' ? 'text-[#32cd32]' : 'text-zinc-600'} />
+            <span
+              className={`mt-3 font-semibold ${when === 'today' ? 'text-white' : 'text-zinc-500'}`}
+            >
+              ASAP
+            </span>
+          </div>
+
+          <div
+            onClick={() => setWhen('date')}
+            className={`${cardBase} ${when === 'date' ? activeCard : inactiveCard}`}
+            style={when === 'date' ? { borderColor: '#32cd32' } : {}}
+          >
+            {when === 'date' && (
+              <CheckCircle2 size={18} className="absolute right-3 top-3 text-[#32cd32]" />
+            )}
+            <Clock size={28} className={when === 'date' ? 'text-[#32cd32]' : 'text-zinc-600'} />
+            <span
+              className={`mt-3 font-semibold ${when === 'date' ? 'text-white' : 'text-zinc-500'}`}
+            >
+              Schedule
+            </span>
+          </div>
+        </div>
+
+        {when === 'date' && (
+          <div className="space-y-4 duration-300 animate-in fade-in slide-in-from-top-3">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <label className="ml-1 text-xs font-bold uppercase tracking-widest text-zinc-500">
+                  Date
+                </label>
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={date}
+                  onChange={e => setDate(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <label className="ml-1 text-xs font-bold uppercase tracking-widest text-zinc-500">
+                  Time
+                </label>
+                <input
+                  type="time"
+                  className={inputClass}
+                  value={time}
+                  onChange={e => setTime(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="mt-4 space-y-1 text-sm">
+          <p className={categoryValid ? 'text-[#32cd32]' : 'text-red-400'}>
+            {categoryValid ? '✓ Category selected' : 'Category is required'}
+          </p>
+          <p className={titleValid ? 'text-[#32cd32]' : 'text-red-400'}>
+            {titleValid ? '✓ Title entered' : 'Title is required'}
+          </p>
+          <p className={budgetValid ? 'text-[#32cd32]' : 'text-red-400'}>
+            {budgetValid ? '✓ Budget entered' : 'Budget must be greater than 0'}
+          </p>
+          <p className={addressValid ? 'text-[#32cd32]' : 'text-red-400'}>
+            {addressValid ? '✓ Address entered' : 'Address is required'}
+          </p>
+          <p className={scheduleValidation.valid ? 'text-[#32cd32]' : 'text-red-400'}>
+            {scheduleValidation.valid ? `✓ ${scheduleValidation.text}` : scheduleValidation.text}
+          </p>
+        </div>
+
+        <div className="mt-10">
+          <button
+            onClick={handleSubmit}
+            disabled={!formReadyToPost || loading}
+            className={`w-full rounded-2xl py-4 font-black uppercase tracking-tight transition-all ${
+              formReadyToPost && !loading
+                ? 'bg-[#32cd32] text-black shadow-lg shadow-[#32cd32]/10 hover:brightness-110 active:scale-[0.97]'
+                : 'pointer-events-none bg-gray-700 text-gray-400'
+            }`}
+          >
+            {loading ? 'Posting...' : 'Post Job'}
+          </button>
+        </div>
       </div>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
### Motivation
- Prevent automatic location prompts on page entry by requesting geolocation only after an explicit user gesture, improving mobile/permission UX and matching dashboard behavior.
- Replace silent/toast-only validation with clear inline validation and button-level guards so users cannot advance with invalid data.
- Enforce a hard image upload limit and provide a clear full-screen submission result UI to avoid backend surprises and improve feedback.

### Description
- Changed the post-job entry flow so geolocation initialization runs only when the user taps the new pre-check `Post Job` CTA; introduced `hasStartedLocationCheck`, `isLocating`, `messageKey`, and `locationReady` states and preserved overlay messages (`initial`, `prompt`, `denied`, `failed`) in `frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/PostJob.jsx`.
- Converted step components to use shared `formData` and moved validation inline: `Step1.jsx`, `Step2.jsx`, `Step5.jsx`, and `Step6.jsx` now show validity indicators and disable the `Next` button until inputs are valid.
- Added an image upload guard in `Step4.jsx` with `MAX_IMAGES = 5`, an inline error message on overflow, and a preview grid with per-image removal.
- Reworked `Step7.jsx` to validate schedule (ASAP vs date/time), aggregate form validation before posting, and show a full-screen success/error modal (with backend reason when available) while avoiding double-posts during loading.
- Small UI/tailwind adjustments and UX cleanups across the modified steps to improve mobile friendliness and touch targets.

### Testing
- Ran `npm --prefix frontend run build`, which completed successfully (Vite build success).
- Started the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173`, which reported the app ready on the specified ports.
- Captured a mobile viewport UI screenshot using Playwright to validate the pre-check CTA and overlay rendering (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699849585878832baf4b7cfb42b90606)