### PR TITLE
Fix client Post-Job location flow trigger and reuse Professional overlay

### DIFF
--- a/frontend/src/Components/LocationAccessOverlay.jsx
+++ b/frontend/src/Components/LocationAccessOverlay.jsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react'
+
+export const LOCATION_OVERLAY_MESSAGES = {
+  initial: 'Getting your location… Please wait',
+  prompt: 'Location access needed – please allow',
+  denied: 'Location permission denied. Please enable it in browser settings to continue.',
+  failed: 'Unable to detect location. Please turn on GPS/location services.',
+}
+
+const LocationAccessOverlay = ({ messageKey, isBlocked }) => {
+  const loaderMessage = useMemo(
+    () => LOCATION_OVERLAY_MESSAGES[messageKey] || LOCATION_OVERLAY_MESSAGES.initial,
+    [messageKey]
+  )
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-[rgb(15,15,16)] px-6 text-center text-white">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-[#32cd32] border-t-transparent" />
+      <p className="max-w-md text-base font-medium">{loaderMessage}</p>
+      {isBlocked && messageKey === 'denied' ? (
+        <a
+          href="https://support.google.com/chrome/answer/142065"
+          target="_blank"
+          rel="noreferrer"
+          className="text-sm text-blue-300 underline"
+        >
+          How to enable location access
+        </a>
+      ) : null}
+    </div>
+  )
+}
+
+export default LocationAccessOverlay

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/Components/JobTabs.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/Components/JobTabs.jsx
@@ -9,6 +9,7 @@ const tabs = [
 
 const JobTabs = () => {
   const setJobTab = useClientStore(state => state.setJobTab)
+  const triggerPostJobFlow = useClientStore(state => state.triggerPostJobFlow)
   const jobTab = useClientStore(state => state.jobTab)
   return (
     <div className="w-[90%]">
@@ -18,7 +19,14 @@ const JobTabs = () => {
           return (
             <div
               key={idx}
-              onClick={() => setJobTab(tab.name)}
+              onClick={() => {
+                if (tab.name === 'Post Jobs') {
+                  triggerPostJobFlow()
+                  return
+                }
+
+                setJobTab(tab.name)
+              }}
               className={`flex h-16 w-16 cursor-pointer items-center justify-center rounded-xl transition-all duration-200 ${
                 isActive ? 'bg-white/10 text-[#32cd32]' : 'hover:bg-white/10 hover:text-[#32cd32]'
               } `}

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/JobPage.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/JobPage.jsx
@@ -7,11 +7,12 @@ import OngoingPage from './OngoingPage'
 
 const JobPage = () => {
   const jobTab = useClientStore(state => state.jobTab)
+  const postJobFlowTrigger = useClientStore(state => state.postJobFlowTrigger)
   return (
     <div className="mt-4 flex flex-col items-center space-y-6 pb-48 text-white">
       <JobTabs />
 
-      {jobTab === 'Post Jobs' && <PostJobPage />}
+      {jobTab === 'Post Jobs' && <PostJobPage trigger={postJobFlowTrigger} />}
       {jobTab === 'Bids' && <BidPage />}
       {jobTab === 'Ongoing Jobs' && <OngoingPage />}
     </div>

--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/PostJob.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/PostJob.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Step1 from './Step1'
 import Step2 from './Step2'
 import Step3 from './Step3'
@@ -8,15 +8,9 @@ import Step6 from './Step6'
 import Step7 from './Step7'
 import useJobStore from '../../../../../store/useJobStore'
 import { getBrowserLocation } from '../../../../../utils/geoLocation.utils'
+import LocationAccessOverlay from '../../../../../Components/LocationAccessOverlay'
 
-const LOCATION_OVERLAY_MESSAGES = {
-  initial: 'Getting your location… Please wait',
-  prompt: 'Location access needed – please allow',
-  denied: 'Location permission denied. Please enable it in your browser settings to continue.',
-  failed: 'Unable to detect location. Please turn on GPS/location services.',
-}
-
-export default function PostJobPage() {
+export default function PostJobPage({ trigger }) {
   const loading = useJobStore(state => state.loading)
   const [step, setStep] = useState(1)
   const [formData, setFormData] = useState({
@@ -31,13 +25,22 @@ export default function PostJobPage() {
   })
 
   const [locationReady, setLocationReady] = useState(false)
-  const [isLocating, setIsLocating] = useState(true)
+  const [isLocating, setIsLocating] = useState(false)
   const [messageKey, setMessageKey] = useState('initial')
+  const [locationRequested, setLocationRequested] = useState(false)
 
   useEffect(() => {
+    if (!trigger) {
+      return
+    }
+
     let isMounted = true
 
     const initializeLocation = async () => {
+      setLocationRequested(true)
+      setLocationReady(false)
+      setIsLocating(true)
+
       if (!('geolocation' in navigator)) {
         setMessageKey('failed')
         setIsLocating(false)
@@ -86,28 +89,15 @@ export default function PostJobPage() {
     return () => {
       isMounted = false
     }
-  }, [])
-
-  const locationMessage = useMemo(
-    () => LOCATION_OVERLAY_MESSAGES[messageKey] || LOCATION_OVERLAY_MESSAGES.initial,
-    [messageKey]
-  )
+  }, [trigger])
 
   const blockedState = !locationReady && !isLocating
 
   return (
     <div className="relative w-[90%]">
-      {!locationReady && (
-        <div className="fixed inset-0 z-[110] flex flex-col items-center justify-center gap-4 bg-[rgb(15,15,16)] px-6 text-center text-white">
-          <div className="h-10 w-10 animate-spin rounded-full border-4 border-[#32cd32] border-t-transparent" />
-          <p className="max-w-md text-base font-medium">{locationMessage}</p>
-          {blockedState ? (
-            <p className="max-w-md text-sm text-zinc-300">
-              Refresh after enabling location access to continue posting your job.
-            </p>
-          ) : null}
-        </div>
-      )}
+      {locationRequested && !locationReady ? (
+        <LocationAccessOverlay messageKey={messageKey} isBlocked={blockedState} />
+      ) : null}
 
       {loading && (
         <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center bg-black/60 backdrop-blur-md transition-all">

--- a/frontend/src/Pages/Dashboard/ProfessionalDashboard/ProfessionalDasboardWrapper.jsx
+++ b/frontend/src/Pages/Dashboard/ProfessionalDashboard/ProfessionalDasboardWrapper.jsx
@@ -1,14 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import useSocketStore from '../../../store/useSocketStore'
 import { getBrowserLocation, watchLocation } from '../../../utils/geoLocation.utils'
-
-const OVERLAY_MESSAGES = {
-  initial: 'Getting your location… Please wait',
-  prompt: 'Location access needed – please allow',
-  denied: 'Location permission denied. Please enable it in browser settings to continue.',
-  failed: 'Unable to detect location. Please turn on GPS/location services.',
-}
+import LocationAccessOverlay from '../../../Components/LocationAccessOverlay'
 
 // This is a wrapper component for the professional dashboard.
 // step 1 set up the socket connection
@@ -92,28 +86,9 @@ const ProfessionalDasboardWrapper = () => {
 
   const locationReady = isConnected && hasCoordinates
   const isBlocked = !locationReady && !isLocating
-  const loaderMessage = useMemo(
-    () => OVERLAY_MESSAGES[messageKey] || OVERLAY_MESSAGES.initial,
-    [messageKey]
-  )
 
   if (!locationReady) {
-    return (
-      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-[rgb(15,15,16)] px-6 text-center text-white">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-[#32cd32] border-t-transparent" />
-        <p className="max-w-md text-base font-medium">{loaderMessage}</p>
-        {isBlocked && messageKey === 'denied' ? (
-          <a
-            href="https://support.google.com/chrome/answer/142065"
-            target="_blank"
-            rel="noreferrer"
-            className="text-sm text-blue-300 underline"
-          >
-            How to enable location access
-          </a>
-        ) : null}
-      </div>
-    )
+    return <LocationAccessOverlay messageKey={messageKey} isBlocked={isBlocked} />
   }
 
   return <Outlet />

--- a/frontend/src/store/useClientStore.js
+++ b/frontend/src/store/useClientStore.js
@@ -2,10 +2,16 @@ import { create } from 'zustand'
 
 const useClientStore = create((set, get) => ({
   mainTab: 'home',
-  jobTab: 'Post Jobs',
+  jobTab: 'Ongoing Jobs',
+  postJobFlowTrigger: 0,
 
-  setMainTab: tab => set({ mainTab: tab, jobTab: 'Post Jobs' }),
+  setMainTab: tab => set({ mainTab: tab, jobTab: 'Ongoing Jobs' }),
   setJobTab: tab => set({ jobTab: tab }),
+  triggerPostJobFlow: () =>
+    set(state => ({
+      jobTab: 'Post Jobs',
+      postJobFlowTrigger: state.postJobFlowTrigger + 1,
+    })),
 }))
 
 export default useClientStore


### PR DESCRIPTION
### Motivation
- The client job-post flow was triggering a geolocation check as soon as the dashboard loaded, causing location checks to run at the wrong time and often to fail on the client side. 
- The goal is to reuse the exact full-screen location overlay used in the Professional Dashboard but only trigger it when the client explicitly clicks `Post Jobs`.

### Description
- Added a shared `LocationAccessOverlay` component and updated the professional wrapper to use it so both flows share identical overlay UI and messages (`frontend/src/Components/LocationAccessOverlay.jsx` and `ProfessionalDasboardWrapper.jsx`).
- Changed client state to default to `Ongoing Jobs`, added a `postJobFlowTrigger` and `triggerPostJobFlow()` in `useClientStore` to start the client location flow only on demand (`frontend/src/store/useClientStore.js`).
- Updated Job tabs so the `Post Jobs` tab calls `triggerPostJobFlow()` and other tabs retain existing behavior (`frontend/src/Pages/Dashboard/ClientDashoard/JobPage/Components/JobTabs.jsx`).
- Wired the trigger to `PostJobPage` via `JobPage` and modified `PostJobPage` so it only runs the geolocation flow when the trigger changes, shows the shared overlay immediately, and only renders the job form after valid coordinates are received (`frontend/src/Pages/Dashboard/ClientDashoard/JobPage/JobPage.jsx` and `PostJobPage/PostJob.jsx`).

### Testing
- Ran `cd frontend && npm run build`, which completed successfully (build warnings about chunk size were reported but build succeeded).
- Launched the dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served the client dashboard route.
- Captured automated Playwright screenshots of the `/Dashboard/clientdashboard` route in desktop and mobile viewports to validate overlay appearance and page behavior (screenshots produced successfully).
- Ran `cd frontend && npm run lint`, which failed in this environment because ESLint reported "No files matching the pattern '.' were found" and is a project configuration issue rather than related to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69984e650eb4832bb726f25238b22d4f)