### PR TITLE
Fix client post-job geolocation hang on mobile

### DIFF
--- a/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step7.jsx
+++ b/frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step7.jsx
@@ -29,8 +29,6 @@ const Step7 = ({ setFormData, formData }) => {
     }
 
     const updatedFormData = { ...formData, scheduledAt: baseDate.toISOString() }
-    console.log(updatedFormData)
-
     try {
       const result = await postJob(updatedFormData)
 
@@ -42,7 +40,19 @@ const Step7 = ({ setFormData, formData }) => {
         setMainTab('home')
       }
     } catch (error) {
-      toast.error(error.response?.data?.message || 'Something went wrong')
+      const fallbackMessage =
+        error?.message ||
+        error?.response?.data?.message ||
+        useJobStore.getState().error ||
+        'Something went wrong'
+
+      console.error('[client-post-job] Submit handler error', {
+        code: error?.code,
+        message: error?.message,
+        responseMessage: error?.response?.data?.message,
+      })
+
+      toast.error(fallbackMessage)
     }
   }
   // Tailwind classes for the Zinc theme

--- a/frontend/src/store/useJobStore.js
+++ b/frontend/src/store/useJobStore.js
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import api from '../api/axios.api'
-import { getBrowserLocation } from '../utils/geoLocation.utils'
+import { GEOLOCATION_ERROR_CODES, getBrowserLocation } from '../utils/geoLocation.utils'
 
 const CLIENT_JOB_STATUS_ORDER = {
   awaiting_review: 0,
@@ -89,7 +89,13 @@ const useJobStore = create((set, get) => ({
 
     try {
       const formData = new FormData()
-      const location = await getBrowserLocation()
+      console.info('[client-post-job] Starting location lookup...')
+      const location = await getBrowserLocation({
+        enableHighAccuracy: true,
+        timeout: 45000,
+        maximumAge: 10000,
+      })
+      console.info('[client-post-job] Location lookup succeeded.', location)
       formData.append('latitude', location.latitude)
       formData.append('longitude', location.longitude)
 
@@ -111,10 +117,24 @@ const useJobStore = create((set, get) => ({
 
       return res.data
     } catch (error) {
-      const errorMsg = error.response?.data?.message || 'Failed to post job'
+      const geoErrorCode = error?.code
+      const geoErrorMessage =
+        geoErrorCode === GEOLOCATION_ERROR_CODES.PERMISSION_DENIED
+          ? 'Location permission was denied. Please allow access and try again.'
+          : geoErrorCode === GEOLOCATION_ERROR_CODES.POSITION_UNAVAILABLE
+            ? 'Unable to determine your location. Please verify location services and retry.'
+            : geoErrorCode === GEOLOCATION_ERROR_CODES.TIMEOUT
+              ? 'Location lookup timed out. Please retry in an open area or switch to Wi-Fi.'
+              : null
+
+      const errorMsg = geoErrorMessage || error.response?.data?.message || 'Failed to post job'
       set({ error: errorMsg, loading: false })
 
-      console.error('Store Error:', errorMsg)
+      console.error('[client-post-job] Post job failed.', {
+        errorCode: error?.code,
+        errorMessage: error?.message,
+        responseMessage: error?.response?.data?.message,
+      })
       throw error
     }
   },

--- a/frontend/src/utils/geoLocation.utils.js
+++ b/frontend/src/utils/geoLocation.utils.js
@@ -1,36 +1,109 @@
 import { socket } from './socket.utils'
 
-export const getBrowserLocation = () => {
+export const GEOLOCATION_ERROR_CODES = {
+  PERMISSION_DENIED: 1,
+  POSITION_UNAVAILABLE: 2,
+  TIMEOUT: 3,
+}
+
+const createGeolocationError = ({ code, message, originalError }) => {
+  const error = new Error(message)
+  error.code = code
+  error.originalError = originalError
+  return error
+}
+
+const DEFAULT_GEO_OPTIONS = {
+  enableHighAccuracy: true,
+  timeout: 8000,
+  maximumAge: 0,
+}
+
+const getSinglePosition = options => {
   return new Promise((resolve, reject) => {
     if (!navigator.geolocation) {
-      return reject(new Error('Geolocation is not supported by your browser.'))
+      return reject(
+        createGeolocationError({
+          code: GEOLOCATION_ERROR_CODES.POSITION_UNAVAILABLE,
+          message: 'Geolocation is not supported by your browser.',
+        })
+      )
     }
+
+    const safeTimeout = Math.max(Number(options?.timeout) || DEFAULT_GEO_OPTIONS.timeout, 1000)
+    const manualTimeout = window.setTimeout(() => {
+      reject(
+        createGeolocationError({
+          code: GEOLOCATION_ERROR_CODES.TIMEOUT,
+          message: 'Location request timed out before the browser returned a response.',
+        })
+      )
+    }, safeTimeout + 2000)
+
     navigator.geolocation.getCurrentPosition(
       position => {
+        window.clearTimeout(manualTimeout)
         resolve({
           latitude: position.coords.latitude,
           longitude: position.coords.longitude,
         })
       },
       error => {
-        reject(new Error(`Failed to get location. Error: ${error.message}`))
+        window.clearTimeout(manualTimeout)
+        reject(
+          createGeolocationError({
+            code: error?.code,
+            message: `Failed to get location. Error: ${error?.message || 'Unknown geolocation error.'}`,
+            originalError: error,
+          })
+        )
       },
-      { enableHighAccuracy: true, timeout: 8000 }
+      options
     )
   })
+}
+
+export const getBrowserLocation = async (options = {}) => {
+  const mergedOptions = { ...DEFAULT_GEO_OPTIONS, ...options }
+
+  try {
+    return await getSinglePosition(mergedOptions)
+  } catch (error) {
+    const timedOutOrUnavailable =
+      error?.code === GEOLOCATION_ERROR_CODES.TIMEOUT ||
+      error?.code === GEOLOCATION_ERROR_CODES.POSITION_UNAVAILABLE
+
+    if (!mergedOptions.enableHighAccuracy || !timedOutOrUnavailable) {
+      throw error
+    }
+
+    const fallbackOptions = {
+      ...mergedOptions,
+      enableHighAccuracy: false,
+      timeout: Math.max(mergedOptions.timeout, 15000),
+      maximumAge: Math.max(mergedOptions.maximumAge ?? 0, 30000),
+    }
+
+    console.info('[geolocation] Retrying with reduced accuracy options.', {
+      initialOptions: mergedOptions,
+      fallbackOptions,
+      errorCode: error?.code,
+      errorMessage: error?.message,
+    })
+
+    return getSinglePosition(fallbackOptions)
+  }
 }
 
 // 1. check if supported
 
 export const watchLocation = () => {
-  console.log("yh i'm here alright")
   if (!('geolocation' in navigator)) {
     throw new Error('Geolocation is not supported by your browser.')
   }
   const watchId = navigator.geolocation.watchPosition(
     position => {
       if (socket.connected) {
-        console.log("yh he's moved")
         socket.emit('update-location', {
           longitude: position.coords.longitude,
           latitude: position.coords.latitude,


### PR DESCRIPTION
### Motivation
- Prevent the client "Post Job" flow from hanging indefinitely on mobile when `navigator.geolocation.getCurrentPosition` never resolves in high-accuracy mode and ensure client behavior matches the professional dashboard flow. 
- Surface clearer diagnostic logs and user-facing messages so developers and testers can quickly identify permission/timeout/unavailable failures.

### Description
- Hardened geolocation logic in `frontend/src/utils/geoLocation.utils.js` by adding explicit `GEOLOCATION_ERROR_CODES`, a `createGeolocationError` wrapper, a manual timeout guard, default geo options, and an automatic retry with `enableHighAccuracy: false` when the first high-accuracy attempt times out or is unavailable. 
- Updated the client job flow in `frontend/src/store/useJobStore.js` to call `getBrowserLocation` with mobile-friendly options (`timeout: 45000`, `maximumAge: 10000`), added start/success/info logs, and mapped geolocation error codes to clearer error messages stored in the job store. 
- Improved UI submit handling in `frontend/src/Pages/Dashboard/ClientDashoard/JobPage/PostJobPage/Step7.jsx` to surface fallback messages to users and emit structured error logs (`code`/`message`) for remote debugging. 
- Removed noisy debug `console.log` lines from `watchLocation` while preserving socket `update-location` emits.

### Testing
- Built the frontend with `npm run build` in the `frontend` folder and the build completed successfully. 
- Ran `npm run lint` in the `frontend` folder which failed because the repo ESLint script currently targets `--ext ts,tsx` and finds no matching files in this JS codebase. 
- No automated unit tests were present for geolocation; behavior changes were implemented with conservative fallbacks and logging to aid manual mobile testing (permission prompt, timeout, and fallback cases).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699853fc9d5c832bafde2f536277c4c4)